### PR TITLE
fix: general bug fixes

### DIFF
--- a/lib/components/layouts/main_layout.dart
+++ b/lib/components/layouts/main_layout.dart
@@ -1305,8 +1305,6 @@ class _MainLayoutState extends State<MainLayout> with TickerProviderStateMixin {
     var scrollOffset = activeController.offset.clamp(0.0, maxScroll);
     final opacity = scrollOffset / maxScroll;
 
-    loggerPrint("Scroll offset: ${activeController.offset}, opacity: $opacity");
-
     if (opacity != aniu.value) {
       setState(() {
         aniu.value = opacity;

--- a/lib/components/music_player/desktop_player_bar.dart
+++ b/lib/components/music_player/desktop_player_bar.dart
@@ -3,6 +3,7 @@ import 'package:cosmodrome/utils/colors.dart';
 import 'package:cosmodrome/utils/tap_area.dart';
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
+import 'package:just_audio/just_audio.dart';
 import 'package:provider/provider.dart';
 
 class DesktopPlayerBar extends StatefulWidget {
@@ -168,8 +169,10 @@ class _DesktopPlayerBarState extends State<DesktopPlayerBar> {
                               onTap: hasSong ? player.skipNext : null,
                             ),
                             _CtrlBtn(
-                              icon: Icons.repeat_rounded,
-                              active: player.repeat,
+                              icon: player.repeatMode == LoopMode.one
+                                  ? Icons.repeat_one_rounded
+                                  : Icons.repeat_rounded,
+                              active: player.repeatMode != LoopMode.off,
                               onTap: hasSong ? player.toggleRepeat : null,
                             ),
                           ],

--- a/lib/components/music_player/desktop_queue_panel.dart
+++ b/lib/components/music_player/desktop_queue_panel.dart
@@ -84,13 +84,12 @@ class DesktopQueuePanel extends StatelessWidget {
             ),
             // queue list
             Expanded(
-              child: Selector<PlayerProvider, (List<Song>, String?)>(
-                selector: (_, p) => (p.queue, p.currentSong?.id),
-                shouldRebuild: (prev, next) =>
-                    prev.$2 != next.$2 || prev.$1.length != next.$1.length,
-                builder: (context, data, _) {
+              child: Selector<PlayerProvider, (int, int)>(
+                selector: (_, p) => (p.queueVersion, p.currentIndex),
+                builder: (context, _, _) {
                   final player = context.read<PlayerProvider>();
-                  final queue = data.$1;
+                  final queue = player.visibleQueue;
+                  final queueOffset = player.visibleQueueStartIndex;
                   if (queue.isEmpty) {
                     return Center(
                       child: Text(
@@ -106,11 +105,13 @@ class DesktopQueuePanel extends StatelessWidget {
                     itemCount: queue.length,
                     itemBuilder: (context, index) {
                       final song = queue[index];
+                      final absoluteIndex = queueOffset + index;
                       return _QueueItem(
-                        key: ValueKey(song.id),
-                        index: index,
+                        key: ValueKey('${song.id}_$absoluteIndex'),
+                        song: song,
+                        isCurrent: player.currentSong?.id == song.id,
                         player: player,
-                        onRemove: () => player.removeFromQueue(index),
+                        onRemove: () => player.removeFromQueue(absoluteIndex),
                       );
                     },
                   );
@@ -125,13 +126,15 @@ class DesktopQueuePanel extends StatelessWidget {
 }
 
 class _QueueItem extends StatefulWidget {
-  final int index;
+  final Song song;
+  final bool isCurrent;
   final PlayerProvider player;
   final VoidCallback onRemove;
 
   const _QueueItem({
     super.key,
-    required this.index,
+    required this.song,
+    required this.isCurrent,
     required this.player,
     required this.onRemove,
   });
@@ -147,8 +150,8 @@ class _QueueItemState extends State<_QueueItem> {
   @override
   Widget build(BuildContext context) {
     final colors = context.theme.colors;
-    final song = widget.player.queue[widget.index];
-    final isCurrent = widget.player.currentSong?.id == song.id;
+    final song = widget.song;
+    final isCurrent = widget.isCurrent;
 
     return MouseRegion(
       onEnter: (_) => setState(() => _isHovered = true),
@@ -227,8 +230,8 @@ class _QueueItemState extends State<_QueueItem> {
   @override
   void didUpdateWidget(_QueueItem oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final song = widget.player.queue[widget.index];
-    final oldSong = oldWidget.player.queue[oldWidget.index];
+    final song = widget.song;
+    final oldSong = oldWidget.song;
     if (song.id != oldSong.id) {
       _coverUrl = widget.player.coverArtUrlForSong(song);
     }
@@ -237,9 +240,7 @@ class _QueueItemState extends State<_QueueItem> {
   @override
   void initState() {
     super.initState();
-    _coverUrl = widget.player.coverArtUrlForSong(
-      widget.player.queue[widget.index],
-    );
+    _coverUrl = widget.player.coverArtUrlForSong(widget.song);
   }
 
   Widget _placeholder() {

--- a/lib/components/music_player/fullscreen_player.dart
+++ b/lib/components/music_player/fullscreen_player.dart
@@ -18,6 +18,7 @@ import 'package:cosmodrome/utils/logger.dart';
 import 'package:cosmodrome/utils/tap_area.dart';
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
+import 'package:just_audio/just_audio.dart';
 import 'package:palette_generator/palette_generator.dart';
 import 'package:provider/provider.dart';
 
@@ -26,6 +27,44 @@ class FullscreenPlayer extends StatefulWidget {
 
   @override
   State<FullscreenPlayer> createState() => _FullscreenPlayerState();
+}
+
+class _FadingAlbumArt extends StatelessWidget {
+  final String imageUrl;
+  final BoxFit fit;
+  final Widget Function(BuildContext context, Object error)? errorBuilder;
+
+  const _FadingAlbumArt({
+    required this.imageUrl,
+    required this.fit,
+    this.errorBuilder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 350),
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      layoutBuilder: (currentChild, previousChildren) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [...previousChildren, ?currentChild],
+        );
+      },
+      transitionBuilder: (child, animation) {
+        return FadeTransition(opacity: animation, child: child);
+      },
+      child: Image.network(
+        imageUrl,
+        key: ValueKey(imageUrl),
+        fit: fit,
+        errorBuilder: errorBuilder != null
+            ? (context, error, stackTrace) => errorBuilder!(context, error)
+            : null,
+      ),
+    );
+  }
 }
 
 class _FullscreenPlayerState extends State<FullscreenPlayer> {
@@ -93,12 +132,13 @@ class _FullscreenPlayerState extends State<FullscreenPlayer> {
                                   sigmaY: 100,
                                   tileMode: TileMode.clamp,
                                 ),
-                                child: Image.network(
-                                  coverUrl,
+                                child: _FadingAlbumArt(
+                                  imageUrl: coverUrl,
                                   fit: BoxFit.cover,
                                 ),
                               ),
-                              if ((_accentColor?.computeLuminance() ?? 0) < 0.15)
+                              if ((_accentColor?.computeLuminance() ?? 0) <
+                                  0.15)
                                 const DecoratedBox(
                                   decoration: BoxDecoration(
                                     color: Colors.black26,
@@ -194,20 +234,19 @@ class _FullscreenPlayerState extends State<FullscreenPlayer> {
                                       child: ClipRRect(
                                         borderRadius: BorderRadius.circular(12),
                                         child: coverUrl != null
-                                            ? Image.network(
-                                                coverUrl,
+                                            ? _FadingAlbumArt(
+                                                imageUrl: coverUrl,
                                                 fit: BoxFit.cover,
-                                                errorBuilder:
-                                                    (ctx, err, stack) {
-                                                      final size =
-                                                          MediaQuery.of(
-                                                            context,
-                                                          ).size.width -
-                                                          64;
-                                                      return _coverPlaceholder(
-                                                        size,
-                                                      );
-                                                    },
+                                                errorBuilder: (ctx, err) {
+                                                  final size =
+                                                      MediaQuery.of(
+                                                        context,
+                                                      ).size.width -
+                                                      64;
+                                                  return _coverPlaceholder(
+                                                    size,
+                                                  );
+                                                },
                                               )
                                             : _coverPlaceholder(
                                                 MediaQuery.of(
@@ -435,10 +474,12 @@ class _FullscreenPlayerState extends State<FullscreenPlayer> {
                                     // repeat
                                     IconButton(
                                       icon: Icon(
-                                        Icons.repeat_rounded,
-                                        color: player.repeat
-                                            ? accent
-                                            : Colors.white38,
+                                        player.repeatMode == LoopMode.one
+                                            ? Icons.repeat_one_rounded
+                                            : Icons.repeat_rounded,
+                                        color: player.repeatMode == LoopMode.off
+                                            ? Colors.white38
+                                            : accent,
                                         size: 26,
                                       ),
                                       onPressed: () => player.toggleRepeat(),
@@ -508,6 +549,7 @@ class _FullscreenPlayerState extends State<FullscreenPlayer> {
           _cacheId = song.id;
         });
       }
+
       return AppColors.background;
     }
 
@@ -544,8 +586,9 @@ class _FullscreenPlayerState extends State<FullscreenPlayer> {
         });
       }
 
-      loggerPrint('Accent color extracted for song: ${song.id}, luminance is ${color?.computeLuminance()}');
-
+      loggerPrint(
+        'Accent color extracted for song: ${song.id}, luminance is ${color?.computeLuminance()}',
+      );
 
       return color;
     } catch (_) {}
@@ -558,7 +601,6 @@ class _FullscreenPlayerState extends State<FullscreenPlayer> {
     if (_lastAccentSongId == song.id) return;
     _lastAccentSongId = song.id;
     _extractAccentColor(song);
-
   }
 
   void _scheduleDismiss() {

--- a/lib/components/music_player/fullscreen_player.dart
+++ b/lib/components/music_player/fullscreen_player.dart
@@ -209,290 +209,333 @@ class _FullscreenPlayerState extends State<FullscreenPlayer> {
 
                     const SizedBox(height: 16),
 
-                    if (song == null)
-                      const Expanded(child: SizedBox.shrink())
-                    else
-                      Expanded(
-                        child: SafeArea(
-                          top: false,
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [
-                              // art
-                              Center(
-                                child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 32,
-                                  ),
-                                  child: ConstrainedBox(
-                                    constraints: const BoxConstraints(
-                                      maxWidth: 500,
-                                      maxHeight: 500,
+                    Expanded(
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 350),
+                        switchInCurve: Curves.easeOut,
+                        switchOutCurve: Curves.easeIn,
+                        layoutBuilder: (currentChild, previousChildren) {
+                          return Stack(
+                            fit: StackFit.expand,
+                            children: [...previousChildren, ?currentChild],
+                          );
+                        },
+                        transitionBuilder: (child, animation) {
+                          return FadeTransition(
+                            opacity: animation,
+                            child: child,
+                          );
+                        },
+                        child: song == null
+                            ? const SizedBox.shrink()
+                            : SafeArea(
+                                key: ValueKey(song.id),
+                                top: false,
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    // art
+                                    Center(
+                                      child: Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 32,
+                                        ),
+                                        child: ConstrainedBox(
+                                          constraints: const BoxConstraints(
+                                            maxWidth: 500,
+                                            maxHeight: 500,
+                                          ),
+                                          child: AspectRatio(
+                                            aspectRatio: 1,
+                                            child: ClipRRect(
+                                              borderRadius:
+                                                  BorderRadius.circular(12),
+                                              child: coverUrl != null
+                                                  ? _FadingAlbumArt(
+                                                      imageUrl: coverUrl,
+                                                      fit: BoxFit.cover,
+                                                      errorBuilder: (ctx, err) {
+                                                        final size =
+                                                            MediaQuery.of(
+                                                              context,
+                                                            ).size.width -
+                                                            64;
+                                                        return _coverPlaceholder(
+                                                          size,
+                                                        );
+                                                      },
+                                                    )
+                                                  : _coverPlaceholder(
+                                                      MediaQuery.of(
+                                                            context,
+                                                          ).size.width -
+                                                          64,
+                                                    ),
+                                            ),
+                                          ),
+                                        ),
+                                      ),
                                     ),
-                                    child: AspectRatio(
-                                      aspectRatio: 1,
-                                      child: ClipRRect(
-                                        borderRadius: BorderRadius.circular(12),
-                                        child: coverUrl != null
-                                            ? _FadingAlbumArt(
-                                                imageUrl: coverUrl,
-                                                fit: BoxFit.cover,
-                                                errorBuilder: (ctx, err) {
-                                                  final size =
+
+                                    const Spacer(),
+
+                                    // title, album & star
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 24,
+                                      ),
+                                      child: Row(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.center,
+                                        children: [
+                                          Expanded(
+                                            child: Column(
+                                              crossAxisAlignment:
+                                                  CrossAxisAlignment.start,
+                                              children: [
+                                                ScrollingText(
+                                                  text: song.title,
+                                                  maxWidth:
                                                       MediaQuery.of(
                                                         context,
                                                       ).size.width -
-                                                      64;
-                                                  return _coverPlaceholder(
-                                                    size,
-                                                  );
-                                                },
-                                              )
-                                            : _coverPlaceholder(
-                                                MediaQuery.of(
-                                                      context,
-                                                    ).size.width -
-                                                    64,
-                                              ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-
-                              const Spacer(),
-
-                              // title, album & star
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 24,
-                                ),
-                                child: Row(
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    Expanded(
-                                      child: Column(
-                                        crossAxisAlignment:
-                                            CrossAxisAlignment.start,
-                                        children: [
-                                          ScrollingText(
-                                            text: song.title,
-                                            maxWidth:
-                                                MediaQuery.of(
-                                                  context,
-                                                ).size.width -
-                                                96,
-                                            style: context.theme.typography.md
-                                                .copyWith(
-                                                  fontWeight: FontWeight.w500,
-                                                  color: Colors.white,
-                                                  height: 1.2,
+                                                      96,
+                                                  style: context
+                                                      .theme
+                                                      .typography
+                                                      .md
+                                                      .copyWith(
+                                                        fontWeight:
+                                                            FontWeight.w500,
+                                                        color: Colors.white,
+                                                        height: 1.2,
+                                                      ),
+                                                  duration: 5,
                                                 ),
-                                            duration: 5,
-                                          ),
-                                          if ((song.album ?? song.artist) !=
-                                              null)
-                                            Text(
-                                              song.album ?? song.artist ?? '',
-                                              style: context.theme.typography.sm
-                                                  .copyWith(
-                                                    color: Colors.white60,
+                                                if ((song.album ??
+                                                        song.artist) !=
+                                                    null)
+                                                  Text(
+                                                    song.album ??
+                                                        song.artist ??
+                                                        '',
+                                                    style: context
+                                                        .theme
+                                                        .typography
+                                                        .sm
+                                                        .copyWith(
+                                                          color: Colors.white60,
+                                                        ),
+                                                    maxLines: 1,
+                                                    overflow:
+                                                        TextOverflow.ellipsis,
                                                   ),
-                                              maxLines: 1,
-                                              overflow: TextOverflow.ellipsis,
+                                              ],
                                             ),
+                                          ),
+                                          IconButton(
+                                            icon: Icon(
+                                              _isStarred
+                                                  ? Icons.star_rounded
+                                                  : Icons.star_border_rounded,
+                                              color: _isStarred
+                                                  ? accent
+                                                  : Colors.white60,
+                                              size: 28,
+                                            ),
+                                            onPressed: _toggleStar,
+                                          ),
                                         ],
                                       ),
                                     ),
-                                    IconButton(
-                                      icon: Icon(
-                                        _isStarred
-                                            ? Icons.star_rounded
-                                            : Icons.star_border_rounded,
-                                        color: _isStarred
-                                            ? accent
-                                            : Colors.white60,
-                                        size: 28,
+
+                                    const SizedBox(height: 8),
+
+                                    // progress bar
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 16,
                                       ),
-                                      onPressed: _toggleStar,
-                                    ),
-                                  ],
-                                ),
-                              ),
-
-                              const SizedBox(height: 8),
-
-                              // progress bar
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 16,
-                                ),
-                                child: SliderTheme(
-                                  data: SliderThemeData(
-                                    trackHeight: 3,
-                                    thumbColor: accent,
-                                    activeTrackColor: accent,
-                                    inactiveTrackColor: Colors.white24,
-                                    overlayColor: accent.withValues(alpha: 0.2),
-                                    thumbShape: SliderComponentShape.noThumb,
-                                    overlayShape: const RoundSliderOverlayShape(
-                                      overlayRadius: 12,
-                                    ),
-                                    trackShape:
-                                        const RoundedRectSliderTrackShape(),
-                                  ),
-                                  child: Slider(
-                                    value: sliderValue,
-                                    min: 0.0,
-                                    max: 1.0,
-                                    activeColor: accent,
-                                    inactiveColor: Colors.white24,
-                                    onChangeStart: (v) {
-                                      if (_closing || !mounted) return;
-                                      setState(() {
-                                        _seeking = true;
-                                        _seekValue = v;
-                                      });
-                                    },
-                                    onChanged: (v) {
-                                      if (_closing || !mounted) return;
-                                      setState(() => _seekValue = v);
-                                    },
-                                    onChangeEnd: (v) {
-                                      if (_closing || !mounted) return;
-                                      setState(() => _seeking = false);
-                                      final seekMs = (v * totalMs).round();
-                                      player.seekTo(
-                                        Duration(milliseconds: seekMs),
-                                      );
-                                    },
-                                  ),
-                                ),
-                              ),
-
-                              // timestamps (dur & pos)
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 28,
-                                ),
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Text(
-                                      _fmt(player.position),
-                                      style: context.theme.typography.xs
-                                          .copyWith(
-                                            color: Colors.white,
-                                            letterSpacing: -0.5,
+                                      child: SliderTheme(
+                                        data: SliderThemeData(
+                                          trackHeight: 3,
+                                          thumbColor: accent,
+                                          activeTrackColor: accent,
+                                          inactiveTrackColor: Colors.white24,
+                                          overlayColor: accent.withValues(
+                                            alpha: 0.2,
                                           ),
+                                          thumbShape:
+                                              SliderComponentShape.noThumb,
+                                          overlayShape:
+                                              const RoundSliderOverlayShape(
+                                                overlayRadius: 12,
+                                              ),
+                                          trackShape:
+                                              const RoundedRectSliderTrackShape(),
+                                        ),
+                                        child: Slider(
+                                          value: sliderValue,
+                                          min: 0.0,
+                                          max: 1.0,
+                                          activeColor: accent,
+                                          inactiveColor: Colors.white24,
+                                          onChangeStart: (v) {
+                                            if (_closing || !mounted) return;
+                                            setState(() {
+                                              _seeking = true;
+                                              _seekValue = v;
+                                            });
+                                          },
+                                          onChanged: (v) {
+                                            if (_closing || !mounted) return;
+                                            setState(() => _seekValue = v);
+                                          },
+                                          onChangeEnd: (v) {
+                                            if (_closing || !mounted) return;
+                                            setState(() => _seeking = false);
+                                            final seekMs = (v * totalMs)
+                                                .round();
+                                            player.seekTo(
+                                              Duration(milliseconds: seekMs),
+                                            );
+                                          },
+                                        ),
+                                      ),
                                     ),
-                                    Text(
-                                      _fmt(player.duration),
-                                      style: context.theme.typography.xs
-                                          .copyWith(
-                                            color: Colors.white,
-                                            letterSpacing: -0.5,
+
+                                    // timestamps (dur & pos)
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 28,
+                                      ),
+                                      child: Row(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.spaceBetween,
+                                        children: [
+                                          Text(
+                                            _fmt(player.position),
+                                            style: context.theme.typography.xs
+                                                .copyWith(
+                                                  color: Colors.white,
+                                                  letterSpacing: -0.5,
+                                                ),
                                           ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-
-                              const SizedBox(height: 24),
-
-                              // controls
-                              Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 16,
-                                ),
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceEvenly,
-                                  children: [
-                                    // shuffle
-                                    IconButton(
-                                      icon: Icon(
-                                        Icons.shuffle_rounded,
-                                        color: player.shuffle
-                                            ? accent
-                                            : Colors.white38,
-                                        size: 26,
+                                          Text(
+                                            _fmt(player.duration),
+                                            style: context.theme.typography.xs
+                                                .copyWith(
+                                                  color: Colors.white,
+                                                  letterSpacing: -0.5,
+                                                ),
+                                          ),
+                                        ],
                                       ),
-                                      onPressed: () => player.toggleShuffle(),
                                     ),
-                                    // prev
-                                    IconButton(
-                                      iconSize: 40,
-                                      icon: const Icon(
-                                        Icons.skip_previous_rounded,
-                                        color: Colors.white,
+
+                                    const SizedBox(height: 24),
+
+                                    // controls
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 16,
                                       ),
-                                      onPressed: () => player.skipPrevious(),
-                                    ),
-                                    // play or pause
-                                    TapArea(
-                                      borderRadius: 40,
-                                      onTap: () => player.togglePlay(),
-                                      child: TweenAnimationBuilder<Color?>(
-                                        tween: ColorTween(
-                                          begin: _prevAccentColor ?? accent,
-                                          end: accent,
-                                        ),
-                                        duration: const Duration(
-                                          milliseconds: 400,
-                                        ),
-                                        builder: (context, color, _) {
-                                          return Container(
-                                            width: 72,
-                                            height: 72,
-                                            decoration: BoxDecoration(
-                                              shape: BoxShape.circle,
-                                              color: (color ?? accent)
-                                                  .withValues(alpha: 0.3),
+                                      child: Row(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.spaceEvenly,
+                                        children: [
+                                          // shuffle
+                                          IconButton(
+                                            icon: Icon(
+                                              Icons.shuffle_rounded,
+                                              color: player.shuffle
+                                                  ? accent
+                                                  : Colors.white38,
+                                              size: 26,
                                             ),
-                                            child: Icon(
-                                              player.isPlaying
-                                                  ? Icons.pause_rounded
-                                                  : Icons.play_arrow_rounded,
+                                            onPressed: () =>
+                                                player.toggleShuffle(),
+                                          ),
+                                          // prev
+                                          IconButton(
+                                            iconSize: 40,
+                                            icon: const Icon(
+                                              Icons.skip_previous_rounded,
                                               color: Colors.white,
-                                              size: 40,
                                             ),
-                                          );
-                                        },
+                                            onPressed: () =>
+                                                player.skipPrevious(),
+                                          ),
+                                          // play or pause
+                                          TapArea(
+                                            borderRadius: 40,
+                                            onTap: () => player.togglePlay(),
+                                            child: TweenAnimationBuilder<Color?>(
+                                              tween: ColorTween(
+                                                begin:
+                                                    _prevAccentColor ?? accent,
+                                                end: accent,
+                                              ),
+                                              duration: const Duration(
+                                                milliseconds: 400,
+                                              ),
+                                              builder: (context, color, _) {
+                                                return Container(
+                                                  width: 72,
+                                                  height: 72,
+                                                  decoration: BoxDecoration(
+                                                    shape: BoxShape.circle,
+                                                    color: (color ?? accent)
+                                                        .withValues(alpha: 0.3),
+                                                  ),
+                                                  child: Icon(
+                                                    player.isPlaying
+                                                        ? Icons.pause_rounded
+                                                        : Icons
+                                                              .play_arrow_rounded,
+                                                    color: Colors.white,
+                                                    size: 40,
+                                                  ),
+                                                );
+                                              },
+                                            ),
+                                          ),
+                                          // skip
+                                          IconButton(
+                                            iconSize: 40,
+                                            icon: const Icon(
+                                              Icons.skip_next_rounded,
+                                              color: Colors.white,
+                                            ),
+                                            onPressed: () => player.skipNext(),
+                                          ),
+                                          // repeat
+                                          IconButton(
+                                            icon: Icon(
+                                              player.repeatMode == LoopMode.one
+                                                  ? Icons.repeat_one_rounded
+                                                  : Icons.repeat_rounded,
+                                              color:
+                                                  player.repeatMode ==
+                                                      LoopMode.off
+                                                  ? Colors.white38
+                                                  : accent,
+                                              size: 26,
+                                            ),
+                                            onPressed: () =>
+                                                player.toggleRepeat(),
+                                          ),
+                                        ],
                                       ),
                                     ),
-                                    // skip
-                                    IconButton(
-                                      iconSize: 40,
-                                      icon: const Icon(
-                                        Icons.skip_next_rounded,
-                                        color: Colors.white,
-                                      ),
-                                      onPressed: () => player.skipNext(),
-                                    ),
-                                    // repeat
-                                    IconButton(
-                                      icon: Icon(
-                                        player.repeatMode == LoopMode.one
-                                            ? Icons.repeat_one_rounded
-                                            : Icons.repeat_rounded,
-                                        color: player.repeatMode == LoopMode.off
-                                            ? Colors.white38
-                                            : accent,
-                                        size: 26,
-                                      ),
-                                      onPressed: () => player.toggleRepeat(),
-                                    ),
+
+                                    SizedBox(height: bottomPadding + 16),
                                   ],
                                 ),
                               ),
-
-                              SizedBox(height: bottomPadding + 16),
-                            ],
-                          ),
-                        ),
                       ),
+                    ),
                   ],
                 ),
               ),

--- a/lib/components/music_player/queue_sheet.dart
+++ b/lib/components/music_player/queue_sheet.dart
@@ -1,5 +1,5 @@
 /*
-  MOBILE ONLY 
+  MOBILE ONLY
   QUEUE SHEET
 
   USE SIDEBAR/SIDE SHEET FOR DESKTOP
@@ -32,55 +32,75 @@ class _QueueSheetState extends State<QueueSheet> {
       borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
       clipBehavior: Clip.antiAlias,
       child: SafeArea(
-        child: Consumer<PlayerProvider>(
-          builder: (context, player, _) {
-            final queue = player.queue;
+        child: Column(
+          children: [
+            const SizedBox(height: 12),
+            Center(
+              child: Container(
+                width: 32,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: context.theme.colors.border,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Queue',
+                  style: context.theme.typography.xl.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: context.theme.colors.foreground,
+                  ),
+                ),
+              ),
+            ),
+            Expanded(
+              child: Selector<PlayerProvider, (int, int)>(
+                selector: (_, p) => (p.queueVersion, p.currentIndex),
+                builder: (context, _, _) {
+                  final player = context.read<PlayerProvider>();
+                  final queue = player.visibleQueue;
+                  final queueOffset = player.visibleQueueStartIndex;
 
-            return Column(
-              children: [
-                const SizedBox(height: 12),
-                Center(
-                  child: Container(
-                    width: 32,
-                    height: 4,
-                    decoration: BoxDecoration(
-                      color: context.theme.colors.border,
-                      borderRadius: BorderRadius.circular(2),
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-                  child: Align(
-                    alignment: Alignment.centerLeft,
-                    child: Text(
-                      'Queue',
-                      style: context.theme.typography.xl.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: context.theme.colors.foreground,
+                  if (queue.isEmpty) {
+                    return Center(
+                      child: Text(
+                        'Queue is empty',
+                        style: context.theme.typography.sm.copyWith(
+                          color: context.theme.colors.mutedForeground,
+                        ),
                       ),
-                    ),
-                  ),
-                ),
-                Expanded(
-                  child: ReorderableListView.builder(
-                    itemCount: queue.length,
+                    );
+                  }
+
+                  return ReorderableListView.builder(
                     key: const Key('queue_list'),
-                    onReorder: player.reorderQueue,
+                    itemCount: queue.length,
+                    onReorder: (oldIndex, newIndex) => player.reorderQueue(
+                      oldIndex + queueOffset,
+                      newIndex + queueOffset,
+                    ),
                     itemBuilder: (context, index) {
                       final song = queue[index];
+                      final absoluteIndex = queueOffset + index;
+                      final coverUrl = _idToCoverUrlCache.putIfAbsent(
+                        song.id,
+                        () => player.coverArtUrlForSong(song) ?? '',
+                      );
+
                       return TapArea(
-                        key: ValueKey(
-                          '${song.id}_$index.${song.title}.${song.artist}.${DateTime.now().millisecondsSinceEpoch}',
-                        ),
+                        key: ValueKey('${song.id}_$absoluteIndex'),
                         onTap: null,
                         child: ListTile(
                           leading: ClipRRect(
                             key: ValueKey('cover_${song.id}'),
                             borderRadius: BorderRadius.circular(4),
                             child: Image.network(
-                              _idToCoverUrlCache[song.id] ?? '',
-
+                              coverUrl,
                               width: 40,
                               height: 40,
                               fit: BoxFit.cover,
@@ -127,18 +147,19 @@ class _QueueSheetState extends State<QueueSheet> {
                                   color: context.theme.colors.mutedForeground,
                                   size: 20,
                                 ),
-                                onPressed: () => player.removeFromQueue(index),
+                                onPressed: () =>
+                                    player.removeFromQueue(absoluteIndex),
                               ),
                             ],
                           ),
                         ),
                       );
                     },
-                  ),
-                ),
-              ],
-            );
-          },
+                  );
+                },
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -147,7 +168,7 @@ class _QueueSheetState extends State<QueueSheet> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final player = Provider.of<PlayerProvider>(context);
+    final player = Provider.of<PlayerProvider>(context, listen: false);
     _getAllCoverUrls(player.queue, player);
   }
 
@@ -159,7 +180,7 @@ class _QueueSheetState extends State<QueueSheet> {
   }
 
   void _getAllCoverUrls(List<Song> songs, PlayerProvider player) {
-    for (var song in songs) {
+    for (final song in songs) {
       if (!_idToCoverUrlCache.containsKey(song.id)) {
         _idToCoverUrlCache[song.id] = player.coverArtUrlForSong(song) ?? '';
       }

--- a/lib/helpers/subsonic-api-helper/subsonic.dart
+++ b/lib/helpers/subsonic-api-helper/subsonic.dart
@@ -7,12 +7,13 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 const _apiVersion = '1.16.1';
-const _cacheTTL = Duration(seconds: 45);
+const _cacheTTL = Duration(seconds: 60 * 5); // 5 minutes
 const _clientName = 'cosmodrome';
+
+final excludedPingEndpoints = {'ping.view', 'getUser'};
 
 // global cache — keyed as "baseUrl|username|endpoint?params"
 final Map<String, ApiResultCache<Map<String, dynamic>>> _apiCache = {};
-
 class ApiResultCache<T> {
   final T data;
   final DateTime timestamp;
@@ -42,10 +43,11 @@ class Subsonic {
     // check to see if theres a cached result that isn't expired
     final cacheKey =
         '$baseUrl|${auth.username}|$endpoint?${params.entries.map((e) => '${e.key}=${e.value}').join('&')}';
-
-    loggerPrint("[Subsonic] API request for $cacheKey");
     final cached = _apiCache[cacheKey];
-    if (cached != null && !cached.isExpired) {
+
+    if (cached != null &&
+        !cached.isExpired &&
+        !excludedPingEndpoints.contains(endpoint)) {
       loggerPrint('Cache hit for $cacheKey');
       return cached.data;
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -90,12 +90,12 @@ void main() async {
   runApp(const Application());
 }
 
+final downloadProvider = DownloadProvider();
+
 final isDesktop =
     !kIsWeb && (Platform.isWindows || Platform.isLinux || Platform.isMacOS);
-
 late final GoRouter router;
 final subsonicProvider = SubsonicProvider();
-final downloadProvider = DownloadProvider();
 
 // go router
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
@@ -163,7 +163,8 @@ class Application extends StatefulWidget {
   State<Application> createState() => _ApplicationState();
 }
 
-class _ApplicationState extends State<Application> with WindowListener {
+class _ApplicationState extends State<Application>
+    with WindowListener, WidgetsBindingObserver {
   RpcBridge? _rpcBridge;
 
   @override
@@ -181,7 +182,8 @@ class _ApplicationState extends State<Application> with WindowListener {
         ChangeNotifierProvider.value(value: subsonicProvider),
         ChangeNotifierProvider.value(value: downloadProvider),
         ChangeNotifierProxyProvider<SubsonicProvider, PlayerProvider>(
-          create: (_) => PlayerProvider()..setDownloadProvider(downloadProvider),
+          create: (_) =>
+              PlayerProvider()..setDownloadProvider(downloadProvider),
           update: (_, sub, player) => player!..update(sub),
         ),
         if (isDesktop && _rpcBridge != null)
@@ -230,7 +232,13 @@ class _ApplicationState extends State<Application> with WindowListener {
   }
 
   @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    subsonicProvider.setAppLifecycleState(state);
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     if (isDesktop) windowManager.removeListener(this);
     super.dispose();
   }
@@ -238,6 +246,8 @@ class _ApplicationState extends State<Application> with WindowListener {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    subsonicProvider.setAppLifecycleState(AppLifecycleState.resumed);
     if (isDesktop) {
       windowManager.addListener(this);
       _rpcBridge = RpcBridge()..init();

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cosmodrome/helpers/subsonic-api-helper/api/browsing.dart';
 import 'package:cosmodrome/helpers/subsonic-api-helper/subsonic.dart';
 import 'package:cosmodrome/helpers/subsonic-api-helper/types/browsing.dart';
@@ -308,7 +310,31 @@ class _HomePageState extends State<HomePage> {
       return;
     }
 
-    setState(() => _loading = true);
+    final cachedRecent = await offlineCacheService.loadRecentAlbums(accountId);
+    final cachedStarred = await offlineCacheService.loadStarredAlbums(
+      accountId,
+    );
+
+    if (provider.isOffline) {
+      if (mounted) {
+        setState(() {
+          _recentAlbums = cachedRecent;
+          _starredAlbums = cachedStarred;
+          _loading = false;
+        });
+      }
+      return;
+    }
+
+    if (mounted && (cachedRecent != null || cachedStarred != null)) {
+      setState(() {
+        _recentAlbums = cachedRecent;
+        _starredAlbums = cachedStarred;
+        _loading = false;
+      });
+    }
+
+    setState(() => _loading = _recentAlbums == null && _starredAlbums == null);
 
     try {
       final results = await Future.wait([
@@ -329,16 +355,14 @@ class _HomePageState extends State<HomePage> {
         });
       }
     } catch (_) {
-      final recent = await offlineCacheService.loadRecentAlbums(accountId);
-      final starred = await offlineCacheService.loadStarredAlbums(accountId);
       if (mounted) {
         setState(() {
-          _recentAlbums = recent;
-          _starredAlbums = starred;
+          _recentAlbums = cachedRecent;
+          _starredAlbums = cachedStarred;
           _loading = false;
         });
-        provider.checkConnectivity();
       }
+      unawaited(provider.checkConnectivity());
     }
   }
 

--- a/lib/pages/library_page.dart
+++ b/lib/pages/library_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cosmodrome/components/library/library_grid_item.dart';
 import 'package:cosmodrome/components/library/song_grid_item.dart';
 import 'package:cosmodrome/components/song_context_sheet.dart';
@@ -46,7 +48,7 @@ class _LibraryPageState extends State<LibraryPage> with LayoutPageMixin {
 
     // if (isMobile(context)) return _buildMobileView();
     // return const SizedBox.shrink();
-    return _buildMobileView(); // TODO: desktop
+    return _buildMobileView(); // TODO: desktop? acc looks fine on desktop tbf
   }
 
   @override
@@ -130,6 +132,7 @@ class _LibraryPageState extends State<LibraryPage> with LayoutPageMixin {
   Widget _buildEmptyState() {
     var gridDelegate = _gridDelegate(context);
 
+    // do simple
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Stack(
@@ -190,35 +193,6 @@ class _LibraryPageState extends State<LibraryPage> with LayoutPageMixin {
         gridDelegate: _gridDelegate(context),
         itemCount: items.length,
         itemBuilder: (ctx, i) => itemBuilder(ctx, items[i], i),
-      ),
-    );
-  }
-
-  Widget _buildLibraryTopBar(BuildContext context) {
-    final topPadding = MediaQuery.of(context).padding.top;
-    final colors = context.theme.colors;
-
-    return Container(
-      height: 56 + topPadding,
-      padding: EdgeInsets.only(top: topPadding, left: 20, right: 8),
-      color: Colors.transparent,
-      child: Column(
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Text(
-                _currentView.title,
-                style: context.theme.typography.xl2.copyWith(
-                  fontWeight: FontWeight.bold,
-                  height: 0,
-                  color: colors.foreground,
-                ),
-              ),
-              const Spacer(),
-            ],
-          ),
-        ],
       ),
     );
   }
@@ -337,6 +311,16 @@ class _LibraryPageState extends State<LibraryPage> with LayoutPageMixin {
     final accountId = provider.activeAccount?.id;
     if (accountId == null) return;
 
+    if (provider.isOffline) {
+      await _loadCachedView(view, accountId);
+      if (mounted) {
+        setState(() {
+          _fetched.add(view);
+        });
+      }
+      return;
+    }
+
     setState(() => _loading.add(view));
 
     try {
@@ -361,22 +345,11 @@ class _LibraryPageState extends State<LibraryPage> with LayoutPageMixin {
       }
       if (mounted) setState(() => _fetched.add(view));
     } catch (_) {
-      // Fall back to cached data when offline
-      switch (view) {
-        case CurrentMobileView.albums:
-          final cached = await offlineCacheService.loadAlbums(accountId);
-          if (mounted && cached != null) setState(() => _albums = cached);
-        case CurrentMobileView.artists:
-          final cached = await offlineCacheService.loadArtists(accountId);
-          if (mounted && cached != null) setState(() => _artists = cached);
-        case CurrentMobileView.playlists:
-          final cached = await offlineCacheService.loadPlaylists(accountId);
-          if (mounted && cached != null) setState(() => _playlists = cached);
-        case CurrentMobileView.songs:
-          final cached = await offlineCacheService.loadSongs(accountId);
-          if (mounted && cached != null) setState(() => _songs = cached);
+      await _loadCachedView(view, accountId);
+      if (mounted) {
+        setState(() => _fetched.add(view));
       }
-      if (mounted) provider.checkConnectivity();
+      unawaited(provider.checkConnectivity());
     } finally {
       if (mounted) setState(() => _loading.remove(view));
     }
@@ -388,7 +361,7 @@ class _LibraryPageState extends State<LibraryPage> with LayoutPageMixin {
   ) {
     final width = MediaQuery.sizeOf(context).width;
     int crossAxisCount = 3;
-    // use the tailscale sorta rules so
+    // use the tailwind (NOT TAILSCALE!!!) sorta rules so
     // <600 = 2
     // 600-900 = 3
     // 900-1200 = 4
@@ -410,6 +383,23 @@ class _LibraryPageState extends State<LibraryPage> with LayoutPageMixin {
       crossAxisSpacing: 12,
       childAspectRatio: 0.72,
     );
+  }
+
+  Future<void> _loadCachedView(CurrentMobileView view, String accountId) async {
+    switch (view) {
+      case CurrentMobileView.albums:
+        final cached = await offlineCacheService.loadAlbums(accountId);
+        if (mounted && cached != null) setState(() => _albums = cached);
+      case CurrentMobileView.artists:
+        final cached = await offlineCacheService.loadArtists(accountId);
+        if (mounted && cached != null) setState(() => _artists = cached);
+      case CurrentMobileView.playlists:
+        final cached = await offlineCacheService.loadPlaylists(accountId);
+        if (mounted && cached != null) setState(() => _playlists = cached);
+      case CurrentMobileView.songs:
+        final cached = await offlineCacheService.loadSongs(accountId);
+        if (mounted && cached != null) setState(() => _songs = cached);
+    }
   }
 
   Future<void> _showCreatePlaylistDialog() async {
@@ -488,7 +478,11 @@ class _OfflineBanner extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const Icon(Icons.wifi_off_rounded, size: 14, color: Color(0xFFFFB300)),
+          const Icon(
+            Icons.wifi_off_rounded,
+            size: 14,
+            color: Color(0xFFFFB300),
+          ),
           const SizedBox(width: 8),
           Text(
             'You are currently offline. Some features may be unavailable.',

--- a/lib/providers/player_provider.dart
+++ b/lib/providers/player_provider.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:math' as math;
+import 'dart:math';
 
 import 'package:cosmodrome/helpers/subsonic-api-helper/api/browsing.dart';
 import 'package:cosmodrome/helpers/subsonic-api-helper/types/browsing.dart';
@@ -10,12 +10,18 @@ import 'package:just_audio/just_audio.dart';
 import 'package:just_audio_background/just_audio_background.dart';
 
 class PlayerProvider extends ChangeNotifier {
+  static final Map<LoopMode, LoopMode> _nextRepeatMode = {
+    LoopMode.off: LoopMode.one,
+    LoopMode.one: LoopMode.all,
+    LoopMode.all: LoopMode.off,
+  };
+
   final AudioPlayer _player = AudioPlayer();
 
-  // canonical ordered list — always kept in sync regardless of shuffle state
   List<Song> _songs = [];
-  // shuffled view — populated only when shuffle is on
-  List<Song> _shuffledSongs = [];
+  final Set<String> _playedSongIds = <String>{};
+  List<int> _shuffleOrder = [];
+  int _shuffleCursor = -1;
 
   int _currentIndex = -1;
   bool _isPlaying = false;
@@ -23,20 +29,19 @@ class PlayerProvider extends ChangeNotifier {
   Duration _duration = Duration.zero;
   SubsonicProvider? _subsonicProvider;
   bool _shuffle = false;
-  bool _repeat = false;
+  LoopMode _repeatMode = LoopMode.off;
   double _volume = 1.0;
+  int _queueVersion = 0;
 
   DownloadProvider? _downloadProvider;
 
-  // Cached once per song so Image.network gets a stable URL.
   String? _cachedCoverArtUrl;
   String? _cachedSongId;
 
   StreamSubscription<Duration>? _positionSub;
   StreamSubscription<Duration?>? _durationSub;
   StreamSubscription<PlayerState>? _stateSub;
-
-  List<Song> get _activeQueue => _shuffle ? _shuffledSongs : _songs;
+  StreamSubscription<int?>? _indexSub;
 
   PlayerProvider() {
     _positionSub = _player.positionStream.listen((pos) {
@@ -49,48 +54,77 @@ class PlayerProvider extends ChangeNotifier {
     });
     _stateSub = _player.playerStateStream.listen((state) {
       _isPlaying = state.playing;
-      if (state.processingState == ProcessingState.completed) {
-        skipNext();
+      notifyListeners();
+    });
+    _indexSub = _player.currentIndexStream.listen((index) {
+      if (index == null || index == _currentIndex) return;
+      _currentIndex = index;
+      if (_shuffle) {
+        _shuffleCursor = _shuffleOrder.indexOf(index);
       }
+      if (index >= 0 && index < _songs.length) {
+        _playedSongIds.add(_songs[index].id);
+      }
+      _updateCoverArtCache();
       notifyListeners();
     });
   }
 
   String? get currentCoverArtUrl => _cachedCoverArtUrl;
 
+  int get currentIndex => _currentIndex;
+
   Song? get currentSong =>
-      _currentIndex >= 0 && _currentIndex < _activeQueue.length
-          ? _activeQueue[_currentIndex]
-          : null;
+      _displayIndex >= 0 && _displayIndex < _activeQueue.length
+      ? _activeQueue[_displayIndex]
+      : null;
 
   Duration get duration => _duration;
   bool get hasCurrentSong => currentSong != null;
   bool get isPlaying => _isPlaying;
   Duration get position => _position;
   List<Song> get queue => List.unmodifiable(_activeQueue);
-  bool get repeat => _repeat;
+  int get queueVersion => _queueVersion;
+  bool get repeat => _repeatMode != LoopMode.off;
+  LoopMode get repeatMode => _repeatMode;
   bool get shuffle => _shuffle;
+  List<Song> get visibleQueue {
+    if (_activeQueue.isEmpty) return const <Song>[];
+    final start = visibleQueueStartIndex;
+    if (start >= _activeQueue.length) return const <Song>[];
+    return List.unmodifiable(_activeQueue.sublist(start));
+  }
+
+  int get visibleQueueStartIndex => _displayIndex < 0 ? 0 : _displayIndex;
   double get volume => _volume;
+
+  List<Song> get _activeQueue {
+    if (!_shuffle || _shuffleOrder.isEmpty) return _songs;
+    return _shuffleOrder
+        .where((index) => index >= 0 && index < _songs.length)
+        .map((index) => _songs[index])
+        .toList();
+  }
+
+  int get _displayIndex => _shuffle ? _shuffleCursor : _currentIndex;
 
   Future<void> addBulkToQueue(List<Song> songs) async {
     _songs.addAll(songs);
     if (_shuffle) {
-      // shuffle only the new songs and insert them after the current position
-      final newSongs = List<Song>.from(songs)..shuffle(math.Random());
-      final insertAt = (_currentIndex + 1).clamp(0, _shuffledSongs.length);
-      _shuffledSongs.insertAll(insertAt, newSongs);
+      _rebuildShuffleOrder();
     }
+    _queueVersion++;
+    await _syncPlayerQueue(preservePosition: true);
     notifyListeners();
   }
 
   Future<void> addToQueue(Song song) async {
     _songs.add(song);
     if (_shuffle) {
-      // insert at a random position after the current song
-      final remaining = _shuffledSongs.length - (_currentIndex + 1);
-      final offset = remaining > 0 ? math.Random().nextInt(remaining + 1) : 0;
-      _shuffledSongs.insert(_currentIndex + 1 + offset, song);
+      _rebuildShuffleOrder();
     }
+    _queueVersion++;
+    await _syncPlayerQueue(preservePosition: true);
     notifyListeners();
   }
 
@@ -111,6 +145,7 @@ class PlayerProvider extends ChangeNotifier {
     _positionSub?.cancel();
     _durationSub?.cancel();
     _stateSub?.cancel();
+    _indexSub?.cancel();
     _player.dispose();
     super.dispose();
   }
@@ -118,14 +153,17 @@ class PlayerProvider extends ChangeNotifier {
   Future<void> playAlbum(List<Song> songs, {bool shuffle = false}) async {
     if (songs.isEmpty) return;
     _songs = List.from(songs);
-    _shuffledSongs = [];
     if (shuffle) {
-      _shuffledSongs = List.from(_songs)..shuffle(math.Random());
-      _shuffle = true;
-    } else {
-      _shuffle = false;
+      _songs.shuffle(Random());
     }
+    _playedSongIds
+      ..clear()
+      ..add(_songs.first.id);
+    _shuffle = shuffle;
     _currentIndex = 0;
+    _shuffleOrder = [];
+    _shuffleCursor = -1;
+    _queueVersion++;
     _updateCoverArtCache();
     notifyListeners();
     await _playCurrentIndex();
@@ -134,10 +172,9 @@ class PlayerProvider extends ChangeNotifier {
   Future<void> playNow(Song song) async {
     final pos = _currentIndex < 0 ? 0 : _currentIndex;
     _songs.insert(pos, song);
-    if (_shuffle) {
-      _shuffledSongs.insert(pos, song);
-    }
     _currentIndex = pos;
+    _playedSongIds.add(song.id);
+    _queueVersion++;
     _updateCoverArtCache();
     notifyListeners();
     await _playCurrentIndex();
@@ -145,14 +182,14 @@ class PlayerProvider extends ChangeNotifier {
 
   Future<void> removeFromQueue(int index) async {
     if (index < 0 || index >= _activeQueue.length) return;
+    var replayedCurrent = false;
     final songId = _activeQueue[index].id;
+    _songs.removeAt(index);
+    _playedSongIds.remove(songId);
     if (_shuffle) {
-      _shuffledSongs.removeAt(index);
-      final idxInSongs = _songs.indexWhere((s) => s.id == songId);
-      if (idxInSongs >= 0) _songs.removeAt(idxInSongs);
-    } else {
-      _songs.removeAt(index);
+      _rebuildShuffleOrder();
     }
+    _queueVersion++;
     if (index < _currentIndex) {
       _currentIndex--;
     } else if (index == _currentIndex) {
@@ -162,19 +199,24 @@ class PlayerProvider extends ChangeNotifier {
       if (_currentIndex >= 0) {
         _updateCoverArtCache();
         await _playCurrentIndex();
+        replayedCurrent = true;
+      } else {
+        await _player.stop();
       }
+    }
+
+    if (!replayedCurrent && _currentIndex >= 0 && _activeQueue.isNotEmpty) {
+      await _syncPlayerQueue(preservePosition: true);
     }
     notifyListeners();
   }
 
   void reorderQueue(int oldIndex, int newIndex) {
     if (oldIndex < newIndex) newIndex -= 1;
+    final song = _songs.removeAt(oldIndex);
+    _songs.insert(newIndex, song);
     if (_shuffle) {
-      final song = _shuffledSongs.removeAt(oldIndex);
-      _shuffledSongs.insert(newIndex, song);
-    } else {
-      final song = _songs.removeAt(oldIndex);
-      _songs.insert(newIndex, song);
+      _rebuildShuffleOrder();
     }
     if (oldIndex == _currentIndex) {
       _currentIndex = newIndex;
@@ -183,15 +225,20 @@ class PlayerProvider extends ChangeNotifier {
     } else if (oldIndex > _currentIndex && newIndex <= _currentIndex) {
       _currentIndex++;
     }
+    _queueVersion++;
+    unawaited(_syncPlayerQueue(preservePosition: true));
     notifyListeners();
   }
 
   Future<void> resetQueue() async {
     _songs.clear();
-    _shuffledSongs.clear();
+    _playedSongIds.clear();
     _currentIndex = -1;
+    _queueVersion++;
     _updateCoverArtCache();
     notifyListeners();
+    _repeatMode = LoopMode.off;
+    await _player.setLoopMode(LoopMode.off);
     await _player.stop();
   }
 
@@ -210,32 +257,66 @@ class PlayerProvider extends ChangeNotifier {
   }
 
   Future<void> skipNext() async {
-    if (_currentIndex >= _activeQueue.length - 1) {
-      if (_repeat) {
-        _currentIndex = 0;
+    if (_shuffle && _shuffleOrder.isNotEmpty) {
+      if (_shuffleCursor < _shuffleOrder.length - 1) {
+        _shuffleCursor++;
+        final targetIndex = _shuffleOrder[_shuffleCursor];
+        await _player.seek(Duration.zero, index: targetIndex);
+        await _player.play();
+        return;
+      }
+
+      if (_repeatMode != LoopMode.off) {
+        _shuffleCursor = 0;
+        await _player.seek(Duration.zero, index: _shuffleOrder.first);
+        await _player.play();
+        return;
+      }
+
+      await _fetchAndAppendRandom();
+      return;
+    }
+
+    if (!_player.hasNext) {
+      if (_repeatMode != LoopMode.off) {
+        _currentIndex = _activeQueue.isEmpty ? -1 : 0;
         _updateCoverArtCache();
         notifyListeners();
-        await _playCurrentIndex();
+        if (_currentIndex >= 0) {
+          await _player.seek(Duration.zero, index: _currentIndex);
+          await _player.play();
+        }
         return;
       }
       await _fetchAndAppendRandom();
     }
-    if (_currentIndex < _activeQueue.length - 1) {
-      _currentIndex++;
-      _updateCoverArtCache();
-      notifyListeners();
-      await _playCurrentIndex();
+    if (_player.hasNext) {
+      await _player.seekToNext();
+      await _player.play();
     }
   }
 
   Future<void> skipPrevious() async {
+    if (_shuffle && _shuffleOrder.isNotEmpty) {
+      if (_position.inSeconds > 3) {
+        await _player.seek(Duration.zero);
+        return;
+      }
+
+      if (_shuffleCursor > 0) {
+        _shuffleCursor--;
+        final targetIndex = _shuffleOrder[_shuffleCursor];
+        await _player.seek(Duration.zero, index: targetIndex);
+        await _player.play();
+      }
+      return;
+    }
+
     if (_position.inSeconds > 3) {
       await _player.seek(Duration.zero);
-    } else if (_currentIndex > 0) {
-      _currentIndex--;
-      _updateCoverArtCache();
-      notifyListeners();
-      await _playCurrentIndex();
+    } else if (_player.hasPrevious) {
+      await _player.seekToPrevious();
+      await _player.play();
     }
   }
 
@@ -247,30 +328,27 @@ class PlayerProvider extends ChangeNotifier {
     }
   }
 
-  void toggleRepeat() {
-    _repeat = !_repeat;
+  Future<void> toggleRepeat() async {
+    _repeatMode = _nextRepeatMode[_repeatMode] ?? LoopMode.off;
+    await _player.setLoopMode(_repeatMode);
     notifyListeners();
   }
 
-  void toggleShuffle() {
-    final currentSongId = currentSong?.id;
+  Future<void> toggleShuffle() async {
+    if (_songs.isEmpty) return;
+
     if (!_shuffle) {
-      // turning ON: shuffle _songs into _shuffledSongs, track current song's new position
-      _shuffledSongs = List.from(_songs)..shuffle(math.Random());
       _shuffle = true;
-      if (currentSongId != null) {
-        final idx = _shuffledSongs.indexWhere((s) => s.id == currentSongId);
-        if (idx >= 0) _currentIndex = idx;
-      }
+      _rebuildShuffleOrder();
+      _shuffleCursor = _shuffleOrder.indexOf(_currentIndex);
     } else {
-      // turning OFF: restore _songs order, find current song's original position
       _shuffle = false;
-      _shuffledSongs = [];
-      if (currentSongId != null) {
-        final idx = _songs.indexWhere((s) => s.id == currentSongId);
-        if (idx >= 0) _currentIndex = idx;
-      }
+      _shuffleOrder = [];
+      _shuffleCursor = -1;
     }
+
+    _queueVersion++;
+    _updateCoverArtCache();
     notifyListeners();
   }
 
@@ -288,34 +366,78 @@ class PlayerProvider extends ChangeNotifier {
   }
 
   Future<void> _playCurrentIndex() async {
-    if (_subsonicProvider == null) return;
-    final song = currentSong;
-    if (song == null) return;
-    try {
-      final localPath = _downloadProvider?.getLocalPath(song.id);
-      final url = localPath != null
-          ? Uri.file(localPath).toString()
-          : _subsonicProvider!.subsonic.streamUrl(song.id);
+    await _syncPlayerQueue(play: true);
+  }
 
-      await _player.setUrl(
-        url,
-        tag: MediaItem(
-          id: song.id,
-          duration: Duration(seconds: song.duration ?? 0),
-          title: song.title,
-          album: song.album,
-          artist: song.artist,
-          artUri: song.coverArt != null
-              ? Uri.parse(
-                  _subsonicProvider!.subsonic.cachedCoverArtUrl(
-                    song.coverArt!,
-                    size: 300,
-                  ),
-                )
-              : null,
-        ),
+  void _rebuildShuffleOrder() {
+    if (!_shuffle || _songs.isEmpty) {
+      _shuffleOrder = [];
+      _shuffleCursor = -1;
+      return;
+    }
+
+    final indices = List<int>.generate(_songs.length, (index) => index);
+    final currentIndex = _currentIndex >= 0 && _currentIndex < _songs.length
+        ? _currentIndex
+        : 0;
+
+    indices.remove(currentIndex);
+    indices.shuffle(Random());
+
+    _shuffleOrder = [currentIndex, ...indices];
+    _shuffleCursor = 0;
+  }
+
+  Future<void> _syncPlayerQueue({
+    bool play = false,
+    bool preservePosition = false,
+    Duration? position,
+  }) async {
+    if (_subsonicProvider == null) return;
+    if (_activeQueue.isEmpty ||
+        _currentIndex < 0 ||
+        _currentIndex >= _activeQueue.length) {
+      return;
+    }
+
+    final seekPosition =
+        position ?? (preservePosition ? _player.position : Duration.zero);
+
+    try {
+      final sources = _activeQueue.map((song) {
+        final localPath = _downloadProvider?.getLocalPath(song.id);
+        final uri = localPath != null
+            ? Uri.file(localPath)
+            : Uri.parse(_subsonicProvider!.subsonic.streamUrl(song.id));
+        return AudioSource.uri(
+          uri,
+          tag: MediaItem(
+            id: song.id,
+            duration: Duration(seconds: song.duration ?? 0),
+            title: song.title,
+            album: song.album,
+            artist: song.artist,
+            artUri: song.coverArt != null
+                ? Uri.parse(
+                    _subsonicProvider!.subsonic.cachedCoverArtUrl(
+                      song.coverArt!,
+                      size: 300,
+                    ),
+                  )
+                : null,
+          ),
+        );
+      }).toList();
+
+      await _player.setAudioSource(
+        ConcatenatingAudioSource(children: sources),
+        initialIndex: _currentIndex,
+        initialPosition: seekPosition,
       );
-      await _player.play();
+      await _player.setLoopMode(_repeatMode);
+      if (play || _player.playing) {
+        await _player.play();
+      }
     } catch (_) {}
   }
 

--- a/lib/providers/subsonic_provider.dart
+++ b/lib/providers/subsonic_provider.dart
@@ -6,7 +6,7 @@ import 'package:cosmodrome/helpers/subsonic-api-helper/api/user.dart';
 import 'package:cosmodrome/helpers/subsonic-api-helper/subsonic.dart';
 import 'package:cosmodrome/providers/subsonic_account.dart';
 import 'package:cosmodrome/utils/logger.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 const _keyAccounts = 'subsonic_accounts';
@@ -26,7 +26,10 @@ class SubsonicProvider extends ChangeNotifier {
   String? _activeId;
   String? _errorMessage;
   bool _isOffline = false;
+  bool _canPollConnectivity = true;
   Timer? _connectivityPoller;
+  final Map<String, int> _connectivityFailureCounts = {};
+  final Map<String, DateTime> _connectivityDebounceUntil = {};
 
   List<SubsonicAccount> get accounts => List.unmodifiable(_accounts);
   SubsonicAccount? get activeAccount => _activeId == null
@@ -44,6 +47,8 @@ class SubsonicProvider extends ChangeNotifier {
     assert(activeAccount != null, 'SubsonicProvider: no active account');
     return activeAccount!.subsonic;
   }
+
+  bool get _canCheckConnectivity => _canPollConnectivity;
 
   /// Adds a new account and makes it active. If an account with the same id
   /// already exists, it will be replaced. Returns an error message on failure.
@@ -133,16 +138,30 @@ class SubsonicProvider extends ChangeNotifier {
 
   /// Pings the active server and updates [isOffline]
   Future<void> checkConnectivity() async {
+    if (!_canCheckConnectivity) return;
+
     final account = activeAccount;
     if (account == null) return;
+
+    final now = DateTime.now();
+    if (_isServerDebounced(account.baseUrl, now)) {
+      return;
+    }
 
     var offline = false;
     try {
       final result = await account.subsonic.ping(timeoutSeconds: 3);
       // auth errors mean we can still "connect" with proper creds
       offline = !result.success && result.errorCode == null;
+
+      if (offline) {
+        _recordServerFailure(account.baseUrl, now);
+      } else {
+        _recordServerSuccess(account.baseUrl);
+      }
     } catch (_) {
       offline = true;
+      _recordServerFailure(account.baseUrl, now);
     }
 
     var changed = false;
@@ -219,6 +238,25 @@ class SubsonicProvider extends ChangeNotifier {
     loggerPrint('SubsonicProvider: removed known server $baseUrl');
     await _persist(); // save known servers to storage
     notifyListeners();
+  }
+
+  void setAppLifecycleState(AppLifecycleState state) {
+    final canPoll = state == AppLifecycleState.resumed;
+    if (_canPollConnectivity == canPoll) {
+      return;
+    }
+
+    _canPollConnectivity = canPoll;
+    if (!canPoll) {
+      _connectivityPoller?.cancel();
+      _connectivityPoller = null;
+      return;
+    }
+
+    if (_authState == AuthState.authenticated && activeAccount != null) {
+      _startConnectivityPolling();
+      unawaited(checkConnectivity());
+    }
   }
 
   /// Switches the active account.
@@ -369,6 +407,19 @@ class SubsonicProvider extends ChangeNotifier {
     }
   }
 
+  bool _isServerDebounced(String baseUrl, DateTime now) {
+    final until = _connectivityDebounceUntil[baseUrl];
+    if (until == null) return false;
+
+    if (!now.isBefore(until)) {
+      _connectivityDebounceUntil.remove(baseUrl);
+      _connectivityFailureCounts.remove(baseUrl);
+      return false;
+    }
+
+    return true;
+  }
+
   // saves accounts to storage! saving!
   Future<void> _persist() async {
     final json = jsonEncode(_accounts.map((a) => a.toJson()).toList());
@@ -387,14 +438,47 @@ class SubsonicProvider extends ChangeNotifier {
     await _getAvatarsForAllAccounts();
   }
 
+  void _recordServerFailure(String baseUrl, DateTime now) {
+    final failureCount = (_connectivityFailureCounts[baseUrl] ?? 0) + 1;
+    if (failureCount >= 3) {
+      _connectivityFailureCounts.remove(baseUrl);
+      _connectivityDebounceUntil[baseUrl] = now.add(
+        const Duration(seconds: 60),
+      );
+      loggerPrint(
+        'SubsonicProvider: debouncing $baseUrl for 60 seconds after repeated connectivity failures',
+      );
+      return;
+    }
+
+    _connectivityFailureCounts[baseUrl] = failureCount;
+  }
+
+  void _recordServerSuccess(String baseUrl) {
+    _connectivityFailureCounts.remove(baseUrl);
+    _connectivityDebounceUntil.remove(baseUrl);
+  }
+
   Future<bool> _refreshKnownServersConnectivity({String? skipBaseUrl}) async {
+    if (!_canCheckConnectivity) return false;
+
     var changed = false;
+    final now = DateTime.now();
     for (final server in knownServers) {
       if (skipBaseUrl != null && server.baseUrl == skipBaseUrl) {
         continue;
       }
+      if (_isServerDebounced(server.baseUrl, now)) {
+        continue;
+      }
+
       final before = server.canConnect;
       final after = await server.tryConnect(timeoutSeconds: 3);
+      if (after) {
+        _recordServerSuccess(server.baseUrl);
+      } else {
+        _recordServerFailure(server.baseUrl, now);
+      }
       if (before != after) {
         changed = true;
       }
@@ -408,6 +492,12 @@ class SubsonicProvider extends ChangeNotifier {
   }
 
   void _startConnectivityPolling() {
+    if (!_canCheckConnectivity) {
+      _connectivityPoller?.cancel();
+      _connectivityPoller = null;
+      return;
+    }
+
     _connectivityPoller?.cancel();
     _connectivityPoller = Timer.periodic(const Duration(seconds: 15), (_) {
       unawaited(checkConnectivity());

--- a/lib/providers/subsonic_provider.dart
+++ b/lib/providers/subsonic_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:cosmodrome/helpers/subsonic-api-helper/api/basic.dart';
@@ -15,8 +16,7 @@ const _keyKnownServers = 'subsonic_known_servers';
 enum AuthState { initial, loading, authenticated, unauthenticated }
 
 class SubsonicProvider extends ChangeNotifier {
-  final _storage = const FlutterSecureStorage(
-  );
+  final _storage = const FlutterSecureStorage();
 
   AuthState _authState = AuthState.initial;
   final List<SubsonicAccount> _accounts = [];
@@ -26,6 +26,7 @@ class SubsonicProvider extends ChangeNotifier {
   String? _activeId;
   String? _errorMessage;
   bool _isOffline = false;
+  Timer? _connectivityPoller;
 
   List<SubsonicAccount> get accounts => List.unmodifiable(_accounts);
   SubsonicAccount? get activeAccount => _activeId == null
@@ -42,25 +43,6 @@ class SubsonicProvider extends ChangeNotifier {
   Subsonic get subsonic {
     assert(activeAccount != null, 'SubsonicProvider: no active account');
     return activeAccount!.subsonic;
-  }
-
-  /// Pings the active server and updates [isOffline]
-  Future<void> checkConnectivity() async {
-    final account = activeAccount;
-    if (account == null) return;
-    try {
-      final result = await account.subsonic.ping(timeoutSeconds: 3);
-      final offline = !result.success && result.errorCode == null;
-      if (offline != _isOffline) {
-        _isOffline = offline;
-        notifyListeners();
-      }
-    } catch (_) {
-      if (!_isOffline) {
-        _isOffline = true;
-        notifyListeners();
-      }
-    }
   }
 
   /// Adds a new account and makes it active. If an account with the same id
@@ -110,6 +92,7 @@ class SubsonicProvider extends ChangeNotifier {
 
       _activeId = account.id;
       _isOffline = false;
+      _startConnectivityPolling();
       await _persist();
       _setState(AuthState.authenticated);
       return null;
@@ -148,6 +131,46 @@ class SubsonicProvider extends ChangeNotifier {
     return success;
   }
 
+  /// Pings the active server and updates [isOffline]
+  Future<void> checkConnectivity() async {
+    final account = activeAccount;
+    if (account == null) return;
+
+    var offline = false;
+    try {
+      final result = await account.subsonic.ping(timeoutSeconds: 3);
+      // auth errors mean we can still "connect" with proper creds
+      offline = !result.success && result.errorCode == null;
+    } catch (_) {
+      offline = true;
+    }
+
+    var changed = false;
+    if (_isOffline != offline) {
+      _isOffline = offline;
+      changed = true;
+    }
+
+    final idx = knownServers.indexWhere((s) => s.baseUrl == account.baseUrl);
+    if (idx >= 0 && knownServers[idx].canConnect != !offline) {
+      knownServers[idx].canConnect = !offline;
+      changed = true;
+    }
+
+    final serverChanged = await _refreshKnownServersConnectivity(
+      skipBaseUrl: account.baseUrl,
+    );
+    if (changed || serverChanged) {
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _connectivityPoller?.cancel();
+    super.dispose();
+  }
+
   /// Removes an account by id. If it was the active account, switches to
   /// the next available one (or sets unauthenticated if none remain).
   Future<void> removeAccount(String id) async {
@@ -169,6 +192,8 @@ class SubsonicProvider extends ChangeNotifier {
     _accounts.clear();
     _activeId = null;
     _errorMessage = null;
+    _connectivityPoller?.cancel();
+    _connectivityPoller = null;
     await _storage.delete(key: _keyAccounts);
     await _storage.delete(key: _keyActiveId);
     loggerPrint('SubsonicProvider: all accounts removed');
@@ -201,10 +226,11 @@ class SubsonicProvider extends ChangeNotifier {
     assert(_accounts.any((a) => a.id == id), 'switchAccount: unknown id $id');
     _activeId = id;
     _isOffline = false;
+    _startConnectivityPolling();
     loggerPrint('SubsonicProvider: switched to $id');
 
     _getAvatarsForActiveAccount();
-    checkConnectivity();
+    unawaited(checkConnectivity());
 
     _storage.write(key: _keyActiveId, value: id);
     notifyListeners();
@@ -250,9 +276,10 @@ class SubsonicProvider extends ChangeNotifier {
         : _accounts.first.id;
 
     _getAvatarsForActiveAccount();
+    _startConnectivityPolling();
     loggerPrint('SubsonicProvider: active account is $_activeId');
     _setState(AuthState.authenticated);
-    checkConnectivity();
+    await checkConnectivity();
   }
 
   Future<void> _getAvatarsForActiveAccount() async {
@@ -321,7 +348,7 @@ class SubsonicProvider extends ChangeNotifier {
         );
 
         // try connecting to the server before adding it to the known servers list
-        final canConnect = await server.tryConnect();
+        final canConnect = await server.tryConnect(timeoutSeconds: 3);
         if (!canConnect) {
           loggerPrint(
             'SubsonicProvider: cannot connect to known server ${server.baseUrl}, skipping',
@@ -360,9 +387,31 @@ class SubsonicProvider extends ChangeNotifier {
     await _getAvatarsForAllAccounts();
   }
 
+  Future<bool> _refreshKnownServersConnectivity({String? skipBaseUrl}) async {
+    var changed = false;
+    for (final server in knownServers) {
+      if (skipBaseUrl != null && server.baseUrl == skipBaseUrl) {
+        continue;
+      }
+      final before = server.canConnect;
+      final after = await server.tryConnect(timeoutSeconds: 3);
+      if (before != after) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
   void _setState(AuthState state) {
     _authState = state;
     notifyListeners();
+  }
+
+  void _startConnectivityPolling() {
+    _connectivityPoller?.cancel();
+    _connectivityPoller = Timer.periodic(const Duration(seconds: 15), (_) {
+      unawaited(checkConnectivity());
+    });
   }
 }
 
@@ -379,7 +428,7 @@ class SubsonicServer {
 
   bool get isLocal => baseUrl.contains('localhost') || baseUrl.contains('100');
 
-  Future<bool> tryConnect() async {
+  Future<bool> tryConnect({int timeoutSeconds = 3}) async {
     // just do a simple get check to see if the server is reachable & we get an error response (since we don't have credentials yet)
     final sub = Subsonic(
       baseUrl: baseUrl,
@@ -390,19 +439,11 @@ class SubsonicServer {
     // ping should fail with a catch of (e), but should expel starting with:
     // Subsonic API error
 
-    loggerPrint(
-      "trying to connect to $baseUrl with dummy credentials to test connectivity",
-    );
-
     try {
-      loggerPrint("pinging $baseUrl...");
-      final res = await sub.ping();
-
-      loggerPrint(
-        "ping response from $baseUrl: success=${res.success}, error=${res.errorMessage}",
-      );
+      final res = await sub.ping(timeoutSeconds: timeoutSeconds);
 
       if (res.success) {
+        // this should never happen so if it does its funny
         loggerPrint(
           'SubsonicServer: unexpected successful ping to $baseUrl with dummy credentials',
         );
@@ -416,11 +457,20 @@ class SubsonicServer {
         canConnect = true;
         return true; // server is reachable and responded with an API error, which is expected
       } else if (res.errorMessage != null) {
-        loggerPrint(
-          'SubsonicServer: received unexpected error from $baseUrl - ${res.errorMessage}',
-        );
+        // unexpected error just means that its blocked too probably
+        // this happens a lot with local IPs since its trying to connect to "itself"
+        // if no response, therefore not reachable rn
         canConnect = false;
         return false; // server is reachable but responded with an unexpected error
+      }
+
+      if (res.errorCode == 404) {
+        // assume that its not a subsonic server
+        loggerPrint(
+          'SubsonicServer: received 404 from $baseUrl, assuming not a Subsonic server',
+        );
+        canConnect = false;
+        return false; // server is reachable but not a Subsonic server
       }
 
       return true; // ping succeeded, server is reachable (but we don't expect this since credentials are wrong)
@@ -430,9 +480,6 @@ class SubsonicServer {
         canConnect = true;
         return true; // server is reachable and responded with an API error, which is expected
       } else {
-        loggerPrint(
-          'SubsonicServer: connection test failed for $baseUrl - $error',
-        );
         canConnect = false;
         return false; // some other error occurred, server might not be reachable
       }

--- a/lib/utils/tap_area.dart
+++ b/lib/utils/tap_area.dart
@@ -63,6 +63,7 @@ class _TapAreaIosState extends State<TapArea> {
     if (widget.onTap == null && widget.onLongTap == null) return content;
 
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTapDown: (_) {
         setState(() {
           _isDown = true;


### PR DESCRIPTION
fixed bugs:

- on the mobile track, you can only start songs by clicking the name of the song rather than the entire thing
- when offline, nothing loads when it should be cached, it's all just spinning circles for the home & nothing inside of the library view.
- when going from offline to online, the status indicators for servers (canConnect) do not update. 
- the queue for mobile scrolling texts do not work since they redraw too much  
- the queue is confusing, it should remove the songs that have already played from the UI, but keep it in the list 
- when shuffling, skipping & then un shuffling you'll be in a different position than you were in, it should try to recover where you left off + remove any songs that have been played already 
- cache for longer 
- results should be cached much longer 
- cannot skip or go back when using the iphone controls (disabled)
- shuffle causing app to temporarily freeze
- shuffle causing app to freeze
- looping not working
- full screen player album art abruptly appearing/disappearing on new song
- stop pinging servers to see if they are alive after a few attempts
- stop pinging servers if app is backgrounded/inactive

features:

- loopmode 1 and all (loop one or all)
- some more probs